### PR TITLE
Config setting showShippingOptions

### DIFF
--- a/frontend/config.json
+++ b/frontend/config.json
@@ -13,7 +13,8 @@
         "notification": "https://example.com/api/ext/payment-klarna/notification"
       }
     },
-    "endpoint": "http://localhost:8080/api/ext/payment-klarna/create-or-update-order"
+    "endpoint": "http://localhost:8080/api/ext/payment-klarna/create-or-update-order",
+    "showShippingOptions": true
   },
   "server": {
     "host": "localhost",

--- a/frontend/payment-klarna/store/getters.ts
+++ b/frontend/payment-klarna/store/getters.ts
@@ -48,7 +48,7 @@ export const getters: GetterTree<CheckoutState, RootState> = {
     if (state.checkout.orderId) {
       checkoutOrder.orderId = state.checkout.orderId
     }
-    if (state.shippingOptions) {
+    if (config.klarna.showShippingOptions && state.shippingOptions) {
       checkoutOrder.shipping_options = shippingMethods.map((method, index: number) => {
         const price = method.price_incl_tax || method.price || 0
         const shippingTaxRate = totals.shipping_tax_amount / totals.shipping_amount


### PR DESCRIPTION
Added new config setting 'showShippingOptions: true' that controls if the available shipping options should be sent to Klarna and displayed in the KCO frame.