### PR TITLE
Upsert Order when cartupdate totals are triggered

### DIFF
--- a/frontend/payment-klarna/components/Checkout.vue
+++ b/frontend/payment-klarna/components/Checkout.vue
@@ -28,11 +28,11 @@ export default {
     }
   },
   async mounted () {
-    setTimeout(async () => {
+    this.$bus.$on('cart-after-updatetotals', async () => {
       this.saveOrderIdToLocalStorage()
       await this.upsertOrder()
       this.saveOrderIdToLocalStorage()
-    }, 100)
+    })
   },
   beforeMount () {
     this.$bus.$on('updateKlarnaOrder', this.configureUpdateOrder())


### PR DESCRIPTION
While reloading checkout page, we will redirect to checkout-redirect then go back to checkout but the KCO will be failed. We need to init Klarna when the totals is synced.