### PR TITLE
Support for VSF 1.10

### DIFF
--- a/frontend/payment-klarna/components/Checkout.vue
+++ b/frontend/payment-klarna/components/Checkout.vue
@@ -44,7 +44,7 @@ export default {
       checkout: 'kco/checkout',
       totals: 'kco/platformTotals',
       hasTotals: 'kco/hasTotals',
-      coupon: 'cart/coupon'
+      coupon: 'kco/coupon'
     })
   },
   watch: {

--- a/frontend/payment-klarna/store/getters.ts
+++ b/frontend/payment-klarna/store/getters.ts
@@ -56,6 +56,10 @@ export const getters: GetterTree<CheckoutState, RootState> = {
   confirmation (state: CheckoutState) {
     return state.confirmation
   },
+  coupon (state, getters, rootState, rootGetters) {
+    // renamed to getCoupon in VSF 1.10
+    return rootGetters['cart/getCoupon'] || rootGetters['cart/coupon']
+  },
   hasTotals (state, getters, rootState) {
     const {platformTotals: totals} = rootState.cart
     return !!totals


### PR DESCRIPTION
Getter `cart/coupon` was renamed to `cart/getCoupon` in VSF 1.10