### PR TITLE
Fix to emit an up-to-date order with data for shipping providers

### DIFF
--- a/API/payment-klarna/index.js
+++ b/API/payment-klarna/index.js
@@ -52,7 +52,7 @@ module.exports = ({ config, db }) => {
         }, 400)
         return
       }
-      apiStatus(res, {orderId: body.order_id, snippet: body.html_snippet, shippingAddress: body.shipping_address})
+      apiStatus(res, {orderId: body.order_id, snippet: body.html_snippet})
     })
   })
 

--- a/frontend/payment-klarna/store/actions.ts
+++ b/frontend/payment-klarna/store/actions.ts
@@ -59,8 +59,7 @@ export const actions: ActionTree<CheckoutState, RootState> = {
     })
     return klarnaResult
   },
-  async confirmation ({ commit, state, dispatch, getters }, { sid }) {
-    commit('getConfirmation')
+  async getOrder ({ commit, state, getters }, sid) {
     const url = config.klarna.confirmation.replace('{{sid}}', sid)
     const { result }: any = await TaskQueue.execute({
       url,
@@ -71,10 +70,15 @@ export const actions: ActionTree<CheckoutState, RootState> = {
       },
       silent: true
     })
+    return result
+  },
+  async confirmation ({ commit, state, dispatch, getters }, { sid }) {
+    commit('getConfirmation')
+    const { result }: any = await dispatch('kco/getOrder', sid)
     const {storageTarget} = getters
     localStorage.removeItem(storageTarget)
     dispatch('cart/clear', null, {root:true})
-    const {html_snippet: snippet, ...klarnaResult} = result
+    const { html_snippet: snippet, ...klarnaResult } = result
     commit('confirmation', {
       snippet,
       scriptsTags: getScriptTagsFromSnippet(snippet)

--- a/frontend/payment-klarna/store/actions.ts
+++ b/frontend/payment-klarna/store/actions.ts
@@ -73,7 +73,7 @@ export const actions: ActionTree<CheckoutState, RootState> = {
   },
   async confirmation ({ commit, state, dispatch, getters }, { sid }) {
     commit('getConfirmation')
-    const { result }: any = await dispatch('kco/getOrder', sid)
+    const { result }: any = await dispatch('kco/fetchOrder', sid)
     const {storageTarget} = getters
     localStorage.removeItem(storageTarget)
     dispatch('cart/clear', null, {root:true})

--- a/frontend/payment-klarna/store/actions.ts
+++ b/frontend/payment-klarna/store/actions.ts
@@ -54,7 +54,6 @@ export const actions: ActionTree<CheckoutState, RootState> = {
     commit('createdOrder', {
       snippet: snippet,
       orderId: klarnaResult.orderId,
-      shippingAddress: klarnaResult.shippingAddress,
       scriptsTags: getScriptTagsFromSnippet(result.snippet)
     })
     return klarnaResult

--- a/frontend/payment-klarna/store/actions.ts
+++ b/frontend/payment-klarna/store/actions.ts
@@ -59,7 +59,7 @@ export const actions: ActionTree<CheckoutState, RootState> = {
     })
     return klarnaResult
   },
-  async getOrder ({ commit, state, getters }, sid) {
+  async fetchOrder ({ commit, state, getters }, sid) {
     const url = config.klarna.confirmation.replace('{{sid}}', sid)
     const { result }: any = await TaskQueue.execute({
       url,


### PR DESCRIPTION
To achieve this I added action `getOrder` and refactored action `confirmation`.

This needs to be scrutinized in the review as to not mess up the confirmation.