### PR TITLE
Bugfix/getter and assumed config

### DIFF
--- a/frontend/payment-klarna/store/getters.ts
+++ b/frontend/payment-klarna/store/getters.ts
@@ -13,7 +13,7 @@ const validateOrder = checkoutOrder => {
   return checkoutOrder.order_amount === sum
 }
 
-const getValue = (attribute, item) => parseFloat(get(item.product, config.klarna.shipping_attributes[attribute], 0)) * item.qty | 0
+const getValue = (attribute, item) => config.klarna.shipping_attributes ? parseFloat(get(item.product, config.klarna.shipping_attributes[attribute], 0)) * item.qty | 0 : 0
 
 const getProductUrl = product => {
   const storeView = currentStoreView()

--- a/frontend/payment-klarna/store/getters.ts
+++ b/frontend/payment-klarna/store/getters.ts
@@ -152,7 +152,7 @@ export const getters: GetterTree<CheckoutState, RootState> = {
   order (state: CheckoutState, getters, rootState, rootGetters) {
     const storeView: any = currentStoreView()
     const shippingMethods = rootState.shipping.methods
-    const cartItems = rootGetters['cart/items']
+    const cartItems = rootGetters['cart/getCartItems']
     const {platformTotals: totals} = rootState.cart
     if (!getters.hasTotals) {
       return {


### PR DESCRIPTION
* Don't assume that the vsf config has anything set for `config.klarna.shipping_attributes`. Caused `undefined property` if no config existed.
* Extended getter `cart/items` was used. In VSF 1.10.0 ´cart/getCartItems` was introduced. Used the `cart/getCartItems` instead. 